### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 Model Context Protocol (MCP) server that controls Xcode directly through JavaScript for Automation (JXA).
 
+<a href="https://glama.ai/mcp/servers/@lapfelix/XcodeMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lapfelix/XcodeMCP/badge" alt="XcodeMCP MCP server" />
+</a>
+
 ## What it does
 
 - Controls Xcode directly through JavaScript for Automation (not xcodebuild CLI)


### PR DESCRIPTION
This PR adds a badge for the [XcodeMCP](https://glama.ai/mcp/servers/@lapfelix/XcodeMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lapfelix/XcodeMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lapfelix/XcodeMCP/badge" alt="XcodeMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.